### PR TITLE
fix so inventory works with non-public aws

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -235,7 +235,7 @@ def aws_host(resource, module_name):
                                              'vpc_security_group_ids'),
         # ansible-specific
         'ansible_ssh_port': 22,
-        'ansible_ssh_host': raw_attrs['public_ip'],
+        'ansible_ssh_host': raw_attrs.get('public_ip', raw_attrs['private_ip']),
     }
 
     if 'tags.sshUser' in raw_attrs:


### PR DESCRIPTION
- apollo/terraform/aws masters and slaves do not have a `public_ip`
  field populated; we want the `private_ip` instead for that case (goes
  through bastion)

More generally, it doesn't look like the recent changes have been tested with apollo/terraform/aws, only with aws-public and gce.
