### PR TITLE
use private_ip when public_ip is empty

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -98,6 +98,16 @@ def calculate_mi_vars(func):
     return inner
 
 
+def _get_ignore_blank(obj, key, default=None):
+    """
+    Get a key in an object, but treat blank string as missing value.
+    """
+    v = obj.get(key, default)
+    if v == "":
+        return default
+    return v
+
+
 def _parse_prefix(source, prefix, sep='.'):
     for compkey, value in source.items():
         try:
@@ -228,7 +238,7 @@ def aws_host(resource, module_name):
         # ansible-specific
         'ansible_ssh_port': 22,
         'ansible_ssh_user': raw_attrs.get('tags.sshUser', 'ubuntu'),
-        'ansible_ssh_host': raw_attrs.get('public_ip', raw_attrs['private_ip']),
+        'ansible_ssh_host': _get_ignore_blank(raw_attrs, 'public_ip', raw_attrs['private_ip']),
     }
 
     # attrs specific to microservices-infrastructure

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from copy import deepcopy
 
 
 @pytest.fixture
@@ -80,6 +81,12 @@ def test_attrs(aws_resource, aws_host, attr, should):
     _, attrs, _ = aws_host(aws_resource, 'module_name')
     assert attr in attrs
     assert attrs[attr] == should
+
+def test_private_ip_default(aws_resource, aws_host):
+    private_resource = deepcopy(aws_resource)
+    private_resource["primary"]["attributes"]["public_ip"] = ""
+    _, attrs, _ = aws_host(private_resource, 'module_name')
+    assert attrs['ansible_ssh_host'] == '10.0.152.191'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
in terraform 0.6.9, the state file injects a public_ip attribute with an
empty string for private aws instances instead of leaving the attribute
absent. terraform.py was injecting blank values for 'ansible_ssh_host'
as a result
